### PR TITLE
Pin undici dependency to version ^6.24.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -712,16 +712,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@fastify/busboy": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/@istanbuljs/schema": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -4494,16 +4484,13 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+			"integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"@fastify/busboy": "^2.0.0"
-			},
 			"engines": {
-				"node": ">=14.0"
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
 		"typescript": "^5.9.3"
 	},
 	"overrides": {
-		"@projectwallace/css-parser": "$@projectwallace/css-parser"
+		"@projectwallace/css-parser": "$@projectwallace/css-parser",
+		"undici": "^6.24.1"
 	},
 	"engines": {
 		"node": ">=20"


### PR DESCRIPTION
## Summary
This PR adds an explicit version override for the `undici` dependency to ensure consistent resolution across the project.

## Changes
- Added `undici` to the `overrides` section in `package.json` with version constraint `^6.24.1`

## Details
The `overrides` field in `package.json` is used to enforce specific versions of dependencies across the entire dependency tree. This change pins `undici` to version 6.24.1 or compatible patch/minor versions, ensuring all transitive dependencies that require `undici` will use this specified version rather than their individually declared versions.

https://claude.ai/code/session_012Zv2tcMjWQWdMaR8Gwirap